### PR TITLE
[fix] : 도커 빌드 시 apt-get update에서 url이 잘못되어 빌드가 안되는 에러

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 
 FROM node:erbium
 
+RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
 RUN apt-get update && apt-get install -y
 
 RUN mkdir -p /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 
 FROM node:erbium
 
-RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' \
+    -e 's|security.debian.org|archive.debian.org/|g' \
+    -e '/stretch-updates/d' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y
 
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
### 도커 빌드 시 apt-get update에서 발생하는 에러 해결

- 기존 ci과정에서 `yarn docker build` 를 실행할 때 다음과 같은 에러발생
```
12.46 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
12.46 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
12.46 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found
12.46 E: Some index files failed to download. They have been ignored, or old ones used instead.
```

- fetch를 하는 url이 잘못되어 발생한 에러로 추정
- docker file에 `RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list`을 추가하여 레포지토리 주소를 업데이트 해줌으로써 해결

