### PR TITLE
[Fix] : 간헐적 test fail 해결

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   reportUnusedDisableDirectives: true,
   rules: {
     'max-len': ['warn', { code: 140 }],
+    'no-plusplus': 'off',
     quotes: [2, 'single', { avoidEscape: true }],
     '@typescript-eslint/no-unused-vars': [
       'warn',

--- a/test/data/mockData.json
+++ b/test/data/mockData.json
@@ -60,12 +60,6 @@
     "date": "today"
   },
   {
-    "to": "USER3",
-    "from": "USER4",
-    "type": "dec",
-    "date": "today"
-  },
-  {
     "to": "USER1",
     "from": "USER2",
     "type": "dec",
@@ -100,6 +94,12 @@
     "from": "USER3",
     "type": "inc",
     "date": "random"
+  },
+  {
+    "to": "USER3",
+    "from": "USER4",
+    "type": "dec",
+    "date": "today"
   },
   {
     "to": "USER2",

--- a/test/lib/seedDatabase.ts
+++ b/test/lib/seedDatabase.ts
@@ -1,23 +1,22 @@
-import * as dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
 import * as fs from 'fs';
+import { MongoMemoryServer } from 'mongodb-memory-server';
 import config from '../../src/config';
 import { env, pathExists, createPath } from '../../src/lib/utils';
 
-import { MongoMemoryServer } from 'mongodb-memory-server';
-
 import databaseDrivers from '../../src/database/drivers';
+// eslint-disable-next-line
 import BurritoStore from '../../src/store/BurritoStore';
 import Localstore from '../../src/store/LocalStore';
 import WBCHandler from '../../src/slack/Wbc';
 import slack from '../../src/slack';
-const mockData = require('../data/mockData');
+
+const mockData = require('../data/mockData.json');
 
 const TYPES = ['give', 'takeaway'];
 let SLACKUSERS = [];
-let mongod, mongoDriver
-
-
+let mongod;
+let mongoDriver;
 
 const today = new Date();
 const yesterDay = new Date(today);
@@ -25,109 +24,118 @@ const oneWeek = new Date(today);
 yesterDay.setDate(yesterDay.getDate() - 1);
 oneWeek.setDate(today.getDate() - 7);
 function pickRandomDate(start, end) {
-    return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
+  return new Date(
+    start.getTime() + Math.random() * (end.getTime() - start.getTime())
+  );
 }
 
 async function give(to, from, date) {
-    await BurritoStore.giveBurrito(to, from, date)
+  await BurritoStore.giveBurrito(to, from, date);
 }
 async function takeaway(to, from, date) {
-    await BurritoStore.takeAwayBurrito(to, from, date)
-
+  await BurritoStore.takeAwayBurrito(to, from, date);
 }
 
 function pickRandom(input) {
-    switch (input) {
-        case 'user':
-            return SLACKUSERS[Math.floor(Math.random() * SLACKUSERS.length)]
-            break;
-    }
+  let result;
+  switch (input) {
+    case 'user':
+      result = SLACKUSERS[Math.floor(Math.random() * SLACKUSERS.length)];
+      break;
+    default:
+  }
+  return result;
 }
-
 
 async function init({ driver = config.db.db_driver, random, seedDB = true }) {
+  // Set and start slack services
+  const { wbc } = slack;
 
-    // Set and start slack services
-    const { wbc } = slack;
+  SLACKUSERS = [];
 
-    SLACKUSERS = []
-
-    if (!pathExists(config.db.db_path)) {
-        if (createPath(config.db.db_path)) {
-        } else {
-            throw new Error('Could not create database path');
-        }
-    }
-
-    await WBCHandler.register(wbc);
-    await Localstore.fetch();
-    const users = await Localstore.getSlackUsers();
-    SLACKUSERS = users.map(x => x.id)
-
-    if (env === 'testing' && driver === 'file') {
-        try {
-            fs.unlinkSync(`${config.db.db_path}${config.db.db_fileName}`);
-        }
-        catch (e) {
-        }
-    };
-
-    if (env === 'testing' && driver === 'mongodb') {
-        mongod = new MongoMemoryServer();
-        const uri = await mongod.getConnectionString();
-        const database = await mongod.getDbName();
-        mongoDriver = databaseDrivers[driver]({ db_uri: uri, db_name: database });
-        BurritoStore.setDatabase(mongoDriver);
+  if (!pathExists(config.db.db_path)) {
+    if (createPath(config.db.db_path)) {
+      //
     } else {
-        BurritoStore.setDatabase(databaseDrivers[driver]())
+      throw new Error('Could not create database path');
     }
+  }
 
+  await WBCHandler.register(wbc);
+  await Localstore.fetch();
+  const users = await Localstore.getSlackUsers();
+  SLACKUSERS = users.map((x) => x.id);
 
-    if (!seedDB) {
-        return {
-            mongoDriver,
-            mongod
-        };
+  if (env === 'testing' && driver === 'file') {
+    try {
+      fs.unlinkSync(`${config.db.db_path}${config.db.db_fileName}`);
+    } catch (e) {
+      //
     }
+  }
 
+  if (env === 'testing' && driver === 'mongodb') {
+    mongod = new MongoMemoryServer();
+    const uri = await mongod.getConnectionString();
+    const database = await mongod.getDbName();
+    mongoDriver = databaseDrivers[driver]({ db_uri: uri, db_name: database });
+    BurritoStore.setDatabase(mongoDriver);
+  } else {
+    BurritoStore.setDatabase(databaseDrivers[driver]());
+  }
 
-    if (random) {
-        for (let i = 1; i <= 100; i++) {
-            const fromUser = pickRandom('user');
-            let toUser = pickRandom('user')
-            while (fromUser === toUser) {
-                toUser = pickRandom('user')
-            }
-
-            const typeBurrito = TYPES[Math.floor(Math.random() * TYPES.length)]
-            switch (typeBurrito) {
-                case 'give':
-                    await give(toUser, fromUser, pickRandomDate(oneWeek, today));
-                    break;
-                case 'takeaway':
-                    await takeaway(toUser, fromUser, pickRandomDate(oneWeek, today))
-                    break;
-            }
-        }
-    } else {
-        mockData.forEach(async (data) => {
-            const date = (data.date === 'random') ? pickRandomDate(oneWeek, yesterDay) : undefined;
-            switch (data.type) {
-                case 'inc':
-                    await give(data.to, data.from, date);
-                    break;
-                case 'dec':
-                    await takeaway(data.to, data.from, date);
-                    break;
-            }
-        });
-
-    }
+  if (!seedDB) {
     return {
-        mongoDriver,
-        mongod
+      mongoDriver,
+      mongod,
     };
+  }
+
+  if (random) {
+    for (let i = 1; i <= 100; i++) {
+      const fromUser = pickRandom('user');
+      let toUser = pickRandom('user');
+      while (fromUser === toUser) {
+        toUser = pickRandom('user');
+      }
+
+      const typeBurrito = TYPES[Math.floor(Math.random() * TYPES.length)];
+      switch (typeBurrito) {
+        case 'give':
+          // eslint-disable-next-line no-await-in-loop
+          await give(toUser, fromUser, pickRandomDate(oneWeek, today));
+          break;
+        case 'takeaway':
+          // eslint-disable-next-line no-await-in-loop
+          await takeaway(toUser, fromUser, pickRandomDate(oneWeek, today));
+          break;
+        default:
+      }
+    }
+  } else {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const data of mockData) {
+      const date =
+        data.date === 'random' ? pickRandomDate(oneWeek, yesterDay) : undefined;
+      switch (data.type) {
+        case 'inc':
+          // eslint-disable-next-line no-await-in-loop
+          await give(data.to, data.from, date);
+          break;
+        case 'dec':
+          // eslint-disable-next-line no-await-in-loop
+          await takeaway(data.to, data.from, date);
+          break;
+        default:
+      }
+    }
+  }
+
+  return {
+    mongoDriver,
+    mongod,
+  };
 }
-export {
-    init,
-}
+
+// eslint-disable-next-line import/prefer-default-export
+export { init };


### PR DESCRIPTION
test DB init 중, 모든 data가 load 완료 될 때 까지 기다리지 않아 간헐적으로 test가 fail하던 문제를 해결했습니다.

mock data를 동기적으로 load하다보니, `BurritoStore`가 score가 0 미만인 경우 `dec` 정보를 무시해 다른 test가 연쇄적으로 fail하는 문제가 발생했습니다. 우선 mock data 순서를 변경해 모든 data가 load 가능하도록 임시 조치해뒀습니다.

최대한 현 lint 룰에 맞춰 수정하려 했지만, [dependency version up이 필요한 경우](https://github.com/typescript-eslint/typescript-eslint/issues/2446)과 같은 몇몇 경우는 disable 했습니다.
